### PR TITLE
Dynamic IP for phpipam_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,28 +707,15 @@ data "phpipam_subnet" "subnet" {
   subnet_mask    = 24
 }
 
-// Get the first available address
-data "phpipam_first_free_address" "next_address" {
-  subnet_id = "${data.phpipam_subnet.subnet.subnet_id}"
-}
-
 // Reserve the address. Note that we use ignore_changes here to ensure that we
 // don't end up re-allocating this address on future Terraform runs.
 resource "phpipam_address" {
   subnet_id   = "${data.phpipam_subnet.subnet.subnet_id}"
-  ip_address  = "${data.phpipam_first_free_address.next_address.ip_address}"
   hostname    = "tf-test-host.example.internal"
   description = "Managed by Terraform"
 
   custom_fields = {
     CustomTestAddresses = "terraform-test"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      "subnet_id",
-      "ip_address",
-    ]
   }
 }
 ```
@@ -739,7 +726,7 @@ The resource takes the following parameters:
 
  * `subnet_id` (Required) - The database ID of the subnet this IP address
    belongs to.
- * `ip_address` (Required) - The IP address to reserve.
+ * `ip_address` (Optional) - The IP address to reserve. If not defined, first free IP in subnet is used.
  * `is_gateway` (Optional) - `true` if this IP address has been designated as a
    gateway.
  * `description` (Optional) - The description provided to this IP address.

--- a/plugin/providers/phpipam/address_structure.go
+++ b/plugin/providers/phpipam/address_structure.go
@@ -101,7 +101,11 @@ func resourceAddressSchema() map[string]*schema.Schema {
 	for k, v := range s {
 		switch {
 		// IP Address and Subnet ID are ForceNew
-		case k == "subnet_id" || k == "ip_address":
+		case k == "ip_address":
+			v.ForceNew = true
+			v.Optional = true
+			v.Computed = true
+		case k == "subnet_id":
 			v.Required = true
 			v.ForceNew = true
 		case k == "custom_fields":

--- a/plugin/providers/phpipam/resource_phpipam_address.go
+++ b/plugin/providers/phpipam/resource_phpipam_address.go
@@ -31,8 +31,13 @@ func resourcePHPIPAMAddressCreate(d *schema.ResourceData, meta interface{}) erro
 	// Assert the ID field here is empty. If this is not empty the request will fail.
 	in.ID = 0
 
-	if _, err := c.CreateAddress(in); err != nil {
+	ip, err := c.CreateAddress(in)
+	if err != nil {
 		return err
+	}
+
+	if in.IPAddress == "" {
+		d.Set("ip_address", ip)
 	}
 
 	// If we have custom fields, set them now. We need to get the IP address's ID


### PR DESCRIPTION
This PR allow to dynamically get and reserve the first free IP in subnet if argument ip_address is not defined when using phpipam_address.